### PR TITLE
Fixed GetFolderNameFromPath() bug.

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -172,14 +172,14 @@ namespace UnityGitSync
         }
         public static string GetFolderNameFromPath(string path)
         {
-            int lastDot = path.LastIndexOf('.');
-            if (lastDot == -1)
+            int lastBackSlash = path.LastIndexOf('\\');
+            if (lastBackSlash == -1)
             {
                 return path;
             }
             else
             {
-                return path.Substring(lastDot + 1);
+                return path.Substring(lastBackSlash + 1);
             }
         }
     }


### PR DESCRIPTION
This is a bug fix for GetFolderNameFromPath() returns incorrect string. #1 